### PR TITLE
Taking the answers skin off of default

### DIFF
--- a/Answers.php
+++ b/Answers.php
@@ -154,8 +154,6 @@ $wgSkinTheme['answers'] = array(
 );
 */
 include( 'NewSkin/NewSkin.php' );
-$wgDefaultSkin = 'answers';
-$wgDefaultTheme = 'bluebell';
 
 // make SkinChooser work for Answers
 /*

--- a/AnswersClass.php
+++ b/AnswersClass.php
@@ -62,7 +62,7 @@ class Answer {
 			return false;
 		}
 
-		if ( $this->title->getNamespace() == NS_ANSWER ) {
+		if ( $this->title->getNamespace() == NS_MAIN ) {
 			return true;
 		}
 

--- a/AnswersHooks.php
+++ b/AnswersHooks.php
@@ -13,8 +13,8 @@ class AnswersHooks {
 	 * @return Boolean: true
 	 */
 	public static function createCanonicalNamespaces( &$list ) {
-		$list[NS_ANSWER] = 'Answer';
-		$list[NS_ANSWER_TALK] = 'Answer_talk';
+		$list[NS_MAIN] = 'Answer';
+		$list[NS_MAIN_TALK] = 'Answer_talk';
 		return true;
 	}
 
@@ -300,7 +300,7 @@ class AnswersHooks {
 				'page_id = rc_cur_id',
 				'rc_new' => 1,
 				'rc_user' => $user_profile->user_id,
-				'page_namespace' => NS_ANSWER,
+				'page_namespace' => NS_MAIN,
 				'page_is_redirect' => 0
 			),
 			__METHOD__,
@@ -317,7 +317,7 @@ class AnswersHooks {
 			$html .= wfMessage( 'answers-no-recently-asked-questions', $user_profile->user_name )->parse();
 		} else {
 			foreach ( $res as $row ) {
-				$questionTitle = Title::makeTitle( NS_ANSWER, $row->page_title );
+				$questionTitle = Title::makeTitle( NS_MAIN, $row->page_title );
 				// question mark might already be there
 				$question = $questionTitle->getText();
 				if ( $question[strlen( $question ) - 1] != '?' ) {
@@ -362,7 +362,7 @@ class AnswersHooks {
 				'page_id = rc_cur_id',
 				'rc_new' => 0,
 				'rc_user' => $user_profile->user_id,
-				'page_namespace' => NS_ANSWER,
+				'page_namespace' => NS_MAIN,
 				'page_is_redirect' => 0
 			),
 			__METHOD__,
@@ -379,7 +379,7 @@ class AnswersHooks {
 			$html .= wfMessage( 'answers-no-recently-edited-questions', $user_profile->user_name )->parse();
 		} else {
 			foreach ( $res as $row ) {
-				$questionTitle = Title::makeTitle( NS_ANSWER, $row->page_title );
+				$questionTitle = Title::makeTitle( NS_MAIN, $row->page_title );
 				// question mark might already be there
 				$question = $questionTitle->getText();
 				if ( $question[strlen( $question ) - 1] != '?' ) {

--- a/AnswersHooks.php
+++ b/AnswersHooks.php
@@ -13,8 +13,8 @@ class AnswersHooks {
 	 * @return Boolean: true
 	 */
 	public static function createCanonicalNamespaces( &$list ) {
-		$list[NS_MAIN] = 'Answer';
-		$list[NS_MAIN_TALK] = 'Answer_talk';
+		$list[NS_MAIN] = '(Main)';
+		$list[NS_TALK] = 'Talk';
 		return true;
 	}
 

--- a/DefaultQuestion.php
+++ b/DefaultQuestion.php
@@ -34,7 +34,7 @@ class DefaultQuestion {
 			}
 		}
 
-		$this->title = Title::makeTitleSafe( NS_ANSWER, $question );
+		$this->title = Title::makeTitleSafe( NS_MAIN, $question );
 		if ( !$this->title ) {
 			return null;
 		}

--- a/EditResearch/EditResearch.php
+++ b/EditResearch/EditResearch.php
@@ -46,12 +46,12 @@ function addEditResearch( $editPage ) {
 	global $wgOut, $wgEditResearchNamespaces;
 
 	$title = $editPage->getTitle();
-	// Only add for enabled namespaces or for NS_ANSWER if $wgEditResearchNamespaces isn't defined
+	// Only add for enabled namespaces or for NS_MAIN if $wgEditResearchNamespaces isn't defined
 	if ( !empty( $wgEditResearchNamespaces ) ) {
 		if ( $wgEditResearchNamespaces[$title->getNamespace()] != true ) {
 			return true;
 		}
-	} elseif ( $title->getNamespace() != NS_ANSWER ) {
+	} elseif ( $title->getNamespace() != NS_MAIN ) {
 		return true;
 	}
 


### PR DESCRIPTION
While this may seem odd, the `$wgDefaultSkin` can (and should) be set in LocalSettings.php. Another reason for this change is that eventually I'm going to want to see this extension integrate into existing skins, not to make its own skin that may be different from the skin that the wiki owner would want to use.
